### PR TITLE
Fix PhantomRunner url on windows os

### DIFF
--- a/lib/PhantomRunner.js
+++ b/lib/PhantomRunner.js
@@ -13,7 +13,7 @@ class PhantomRunner extends QUnitRunner {
     }
 
     run(stream, file, callback) {
-        let url = 'file://' + path.resolve(file.path).replace(/\\/g, '/');
+        let url = 'file:///' + path.resolve(file.path).replace(/\\/g, '/').replace(/^\//, '');
         if (this.options.checkGlobals)
             url += '?noglobals';
 


### PR DESCRIPTION
On windows the path is file://C:/ instead of file:///C:/ (missing a /) and the testrunner will timeout. This makes sure the url always starts with file:///