### PR TITLE
Terminate hanging phantomjs processes on Windows

### DIFF
--- a/lib/PhantomRunner.js
+++ b/lib/PhantomRunner.js
@@ -1,6 +1,7 @@
 'use strict';
 
-let childProcess = require('child_process'),
+let os = require('os'),
+    childProcess = require('child_process'),
     gutil = require('gulp-util'),
     path = require('path'),
     phantomjs = require('phantomjs-prebuilt'),
@@ -52,6 +53,15 @@ class PhantomRunner extends QUnitRunner {
                 type: 'error',
                 data: data.toString()
             });
+        });
+
+        // terminate hanging phantomjs processes on Windows
+        this.child.on('exit', () => {
+            if (os.type() === 'Windows_NT') {
+                setTimeout(() => {
+                    childProcess.exec('taskkill /F /IM phantomjs.exe');
+              }, 500);
+            }
         });
     }
 }

--- a/lib/QUnitRunner.js
+++ b/lib/QUnitRunner.js
@@ -74,7 +74,7 @@ class QUnitRunner {
         let kill = () => {
             process.removeListener('exit', kill);
             this.child.kill();
-        }
+        };
 
         process.on('exit', kill);
 


### PR DESCRIPTION
On Windows the testrunner hangs and has to be terminated by CTRL+C. This is due to phantomjs.exe not exiting, this also leaves background processes running. I added handler that terminates all phantomjs-processes after a timeout if os is Windows_NT. This was the solution I could find on google (it seems to happen on Windows only) and it feels like a hack. 

Another working solution is to just run process.exit() in kill-method.

One other not related thing, when spawning the child process (PhantomRunner.js:23) the last argument (callback) is not supported if looking at the node docs.